### PR TITLE
Implementation for center of mass calculation in parallel

### DIFF
--- a/OctTree.h
+++ b/OctTree.h
@@ -44,6 +44,8 @@ public:
     vector_3d pos;
     vector_3d lowerBound;
     vector_3d upperBound;
+    double mass;
+    vector_3d centerOfMass;
     int numChildren;
     Node **children;
 }; // end class Root
@@ -66,10 +68,14 @@ public:
     // Helper function to remove Leaf from tree and rebalance tree
     void remove(Leaf *particle);
 
-    // Helper function to maybe replace Root node with Leaf
+    // Helper function to maybe replace Root node with Leaf node
     void maybeReplaceRoot(Root *root);
 
-    // Helper function to print Tree
+    // Helper functions to set center of mass for each Root node
+    void setCenterOfMass();
+    void centerOfMass(Root *root);
+
+    // Helper functions to print Tree
     void print();
     void printRecurse(Root *root);
 private:

--- a/main.cpp
+++ b/main.cpp
@@ -10,11 +10,12 @@
 
 int main()
 {
-    // Generate particle inputs and 3D bounds
-    vector_3d lowerBound = std::make_tuple(0, 0, 0);
-    vector_3d upperBound = std::make_tuple(24, 24, 0);
+    // Get command line args:
+    //  steps     - number of time steps to simulate
+    //  inputFile - path to input file, which contains simulation bounds and particles
 
-    // Construct a set of Leaf pointers that encapsulate each particle.
+    // Parse input file and construct vector of Leaf objects
+
     // Memory allocated for Leaf is owned by OctTree and is freed when OctTree is destructed.
     std::vector<Leaf *> particles = {
         new Leaf(nullptr,
@@ -35,26 +36,15 @@ int main()
                  Body(8, 1, std::make_tuple(22, 8, 0), zero_vect(), zero_vect()))
     };
 
-    // Construct OctTree
-    OctTree tree = OctTree(particles, lowerBound, upperBound);
+    // Construct OctTree from vector of particles
+    OctTree tree = OctTree(particles, std::make_tuple(0, 0, 0), std::make_tuple(24, 24, 0));
 
-    // Print OctTree
-    tree.print();
-    std::cout << std::endl;
+    // Update OctTree to cache center of mass for each octet at Root node
+    tree.setCenterOfMass();
 
-    // Update particle position to change octets
-    particles[0]->body.pos = std::make_tuple(10,13,0);
-
-    // Remove particle from tree and re-insert
-    tree.remove(particles[0]);
-    tree.print();
-    std::cout << std::endl;
-    tree.insert(particles[0]);
-    tree.print();
-    std::cout << std::endl;
-    tree.remove(particles[0]);
     tree.print();
 
-    //std::cout << std::endl;
-    //Body::demo();
+    // Perform Barnes-Hut simulation for given number of time steps
+    //
+    // After each iteration, update OctTree structure and cached centers of mass
 }


### PR DESCRIPTION
Added function that sets center of mass for each node in `OctTree`. Implementation spawns thread for each `Root` node and calculates center of mass for node after all children are finished.